### PR TITLE
fix: downgrade dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v1.0.1
+
+- Downgrade android minSDk to 22 (Stone requirement)
+- Updated Stone SDK version (4.11.2);
+
 ## v1.0.0
 
 - New method `cancelPayment`;

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Para usar este pacote, adicione `stone_payments` como uma dependência em seu ar
 
 ```yaml
 dependencies:
-  stone_payments: ^1.0.0
+  stone_payments: ^1.0.1
 ```
 
 Em seguida, execute `flutter pub get` para instalar o pacote.
@@ -26,10 +26,10 @@ Inclua no arquivo **local.properties**, localizado na raiz do projeto, a variáv
 packageCloudReadToken=SEU_TOKEN
 ```
 
-O minSdkVersion deve ser igual ou maior que 23
+O minSdkVersion deve ser igual ou maior que 22
 
 ```
-minSdkVersion=23
+minSdkVersion=22
 ```
 
 ##### Atenção!

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,7 @@ version '1.0-SNAPSHOT'
 buildscript {
     ext {
         kotlin_version = '1.9.0'
-        stone_sdk_version = '4.10.2'
+        stone_sdk_version = '4.11.2'
 
         localProp = new Properties()
         fileName = 'local.properties'
@@ -58,7 +58,7 @@ android {
     }
 
     defaultConfig {
-        minSdk 23
+        minSdk 22
     }
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stone_payments
 description: Este pacote é um plugin que fornece integração com as máquinas de pagamento da empresa Stone.
-version: 1.0.0
+version: 1.0.1
 homepage: https://github.com/Leleocastro/stone_payments
 
 environment:


### PR DESCRIPTION
Recentemente tentamos homologar um APP juntamente a stone e eles exigiram essas alterações.
Atualização da versão de biblioteca.
Downgrade do minSdk para 22 para maior compatibilidade com os modelos Stone